### PR TITLE
Create shares root first

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,14 @@
     - samba_export_all_rw
   tags: samba
 
+- name: Create Samba shares root directory
+  file:
+    state: directory
+    path: "{{ samba_shares_root }}"
+    owner: root
+    group: root
+    mode: '0755'
+
 - name: Create share directories
   with_items: samba_shares
   file:


### PR DESCRIPTION
Currently, when creating share directories, samba_shares_root is created at the same time and with the same group owner and directory mode as the first share defined in samba_shares.

This may have some unwanted effects, depending on the settings for that first share (certainly if default mode 0775 is in effect for the share).  It may give control over share folders to some (local) users who shouldn't have it. 

With this pull request, samba_shares_root will be created in a separate step, with root/root as owner/group and mode 0755.