### PR TITLE
Allow specific path for shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A complete overview of share options follows below. Only `name` is required, the
 | Option                 | Default | Comment                                                                                        |
 | :---                   | :---    | :---                                                                                           |
 | `name`                 | -       | The name of the share.                                                                         |
+| `path`                 | /{{samba_shares_root}}/{{name}}       | The path to the share directory.                                   |
 | `comment`              | -       | A comment string for the share                                                                 |
 | `public`               | `no`    | Controls read access for guest users                                                           |
 | `valid_users`          | -       | Controls read access for registered users. Use the syntax of the corresponding Samba setting.  |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
   with_items: samba_shares
   file:
     state: directory
-    path: "{{ samba_shares_root}}/{{ item.name }}"
+    path: "{{ item.path|default([samba_shares_root,item.name]|join('/')) }}"
     owner: root
     group: "{{ item.group|default('users') }}"
     mode: "{{ item.directory_mode|default('0775') }}"
@@ -55,7 +55,7 @@
   file:
     state: link
     path: "/var/www/html/{{ item.name }}"
-    src: "{{ samba_shares_root }}/{{ item.name }}"
+    src: "{{ item.path|default([samba_shares_root,item.name]|join('/')) }}"
   with_items: samba_shares
   tags: samba
 

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -53,7 +53,7 @@
 {% if share.comment is defined %}
   comment = {{ share.comment }}
 {% endif %}
-  path = {{ samba_shares_root }}/{{ share.name }}
+  path = {{ share.path|default([samba_shares_root,share.name]|join('/')) }}
   public = {{ share.public|default('no') }}
 {% if share.valid_users is defined %}
   valid users= {{ share.valid_users }}


### PR DESCRIPTION
This makes it possible to define a file path for each share rather than the default of building it from the share name.