### PR TITLE
Fixed an issue with the "Create Samba users if they don't exist yet" task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,7 +93,7 @@
 
 - name: Create Samba users if they don't exist yet
   shell: >
-    (pdbedit -L | grep {{ item.name }} 2>&1 > /dev/null) \
+    (pdbedit --user={{ item.name }} 2>&1 > /dev/null) \
     || (echo {{ item.password }}; echo {{ item.password }}) \
     | smbpasswd -s -a {{ item.name }}
   with_items: "{{ samba_users }}"


### PR DESCRIPTION
Fixed a problem that occurs when adding users with usernames that are part of already existing usernames (e.g. when alexander exists, you won't be able to add user alex).