### PR TITLE
modifiy conditional expressions of ansible_selinux

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ samba_selinux_packages }}"
-  when: ansible_selinux
+  when: ansible_selinux.status == 'enabled'
   tags: samba
 
 - name: Make sure SELinux boolean settings are correct
@@ -28,7 +28,7 @@
     state: yes
     persistent: yes
   with_items: "{{ samba_selinux_booleans }}"
-  when: ansible_selinux
+  when: ansible_selinux.status == 'enabled'
   tags: samba
 
 - name: Create Samba shares root directory


### PR DESCRIPTION
The fact `ansible_selinux` is used in the task for determining whether SELinux is enabled or disabled.
Unfortunately, `when: ansible_selinux` seems to return always true, because it is dict.
So the running the playbook fails if the user disables SELinux.
