### PR TITLE
Add support for disabling WINs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ No specific requirements
 | `samba_users`                  | []                       | List of dicts defining users that can access shares.                  |
 | `samba_workgroup`              | `WORKGROUP`              | Name of the server workgroup.                                         |
 | `samba_guest_account`          | -                        | Guest account for unknown users                                       |
+| `samba_wins_support`           | true                     | When true, Samba will act as a WINS server                            |
+| `samba_local_master`           | true                     | When true, nmbd will try & become local master of the subnet          |
+| `samba_domain_master`          | true                     | When true, smbd enables WAN-wide browse list collation                |
+| `samba_preferred_master`       | true                     | When true, indicates nmbd is a preferred master browser for workgroup |
 
 ### Defining users
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,8 @@ samba_create_varwww_symlinks: false
 samba_shares_root: '/srv/shares'
 samba_shares: []
 samba_users: []
+
+samba_wins_support: yes
+samba_local_master: yes
+samba_domain_master: yes
+samba_preferred_master: yes

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -32,10 +32,10 @@
 {% endif %}
 
   # Name resolution: make sure \\NETBIOS_NAME\ works
-  wins support = yes
-  local master = yes
-  domain master = yes
-  preferred master = yes
+  wins support = {{ samba_wins_support | ternary('yes', 'no') }}
+  local master = {{ samba_local_master | ternary('yes', 'no') }}
+  domain master = {{ samba_domain_master | ternary('yes', 'no') }}
+  preferred master = {{ samba_preferred_master | ternary('yes', 'no') }}
 
 {% if not samba_load_printers %}
   # Don't load printers


### PR DESCRIPTION
When in conditions where the NetBIOS name is not always ideally resolvable or has conflicting firewall policy, this becomes necessary.