### PR TITLE
Added support for Realmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ No specific requirements
 | `samba_map_to_guest`           | `bad user`               | Behaviour when unregistered users access the shares.                  |
 | `samba_netbios_name`           | `{{ ansible_hostname }}` | The NetBIOS name of this server.                                      |
 | `samba_passdb_backend`         | `tdbsam`                 | Password database backend.                                            |
+| `samba_realm`                  | -                        | Realm domain name                                                 |
 | `samba_security`               | `user`                   | Samba security setting                                                |
 | `samba_server_string`          | `fileserver %m`          | Comment string for the server.                                        |
 | `samba_shares`                 | []                       | List of dicts containing share definitions. See below for details.    |

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -8,7 +8,10 @@
   netbios name = {% if samba_netbios_name is defined %}{{ samba_netbios_name }}{% else %}{{ ansible_hostname }}{% endif %}
 
   workgroup = {{ samba_workgroup }}
-  server string = {{ samba_server_string }}
+{% if samba_realm is defined %}
+  realm = {{ samba_realm }}
+{% endif %}
+server string = {{ samba_server_string }}
 
   # Logging
 {% if samba_log is defined %}


### PR DESCRIPTION
This adds a new variable "samba_realm" to the role. This variable is only needed when your VM is joined to an already existing domain by using realmd, and you want to configure this member server as a samba file server.
Minor update to the README.MD as well, adding the new variable.