### PR TITLE
Added username map configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,6 +76,15 @@
     - Restart Samba services
   tags: samba
 
+- name: Create username map file if needed
+  template:
+    dest: "{{ samba_username_map_file }}"
+    src: smbusers.j2
+  notify:
+    - Restart Samba services
+  tags: samba
+  when: samba_username_map is defined
+
 - name: Start Samba service(s)
   service:
     name: "{{ item }}"

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -29,6 +29,9 @@ server string = {{ samba_server_string }}
 {% if samba_guest_account  is defined %}
   guest account = {{ samba_guest_account }}
 {% endif %}
+{% if samba_username_map is defined %}
+  username map = {{ samba_username_map_file }}
+{% endif %}
 
 {% if samba_interfaces|length > 0 %}
   interfaces = {{ samba_interfaces }}

--- a/templates/smbusers.j2
+++ b/templates/smbusers.j2
@@ -1,0 +1,3 @@
+{% for entry in samba_username_map %}
+{{ entry.to }} = {{ entry.from }}
+{% endfor %}

--- a/vars/os_Archlinux.yml
+++ b/vars/os_Archlinux.yml
@@ -9,6 +9,7 @@ samba_selinux_packages: []
 samba_selinux_booleans: []
 
 samba_configuration: /etc/samba/smb.conf
+samba_username_map_file: /etc/samba/smbusers
 
 samba_services:
   - smbd

--- a/vars/os_Debian.yml
+++ b/vars/os_Debian.yml
@@ -10,6 +10,7 @@ samba_selinux_packages: []
 samba_selinux_booleans: []
 
 samba_configuration: /etc/samba/smb.conf
+samba_username_map_file: /etc/samba/smbusers
 
 # The name of the Samba service in older releases (Ubuntu 14.04,
 # Debian <8) is "samba".

--- a/vars/os_RedHat.yml
+++ b/vars/os_RedHat.yml
@@ -14,6 +14,7 @@ samba_selinux_booleans:
   - samba_export_all_rw
 
 samba_configuration: /etc/samba/smb.conf
+samba_username_map_file: /etc/samba/smbusers
 
 samba_services:
   - smb


### PR DESCRIPTION
This PR makes username map configurable.
Users are supposed to set `samba_username_map` variable as follows:
```
samba_username_map:
  - { from: 'UserOnWindows', to: 'userOnLinux' }
  - { from: 'foo', to: 'bar' }
```

which is equal to username map as follows:
```
userOnLinux = UserOnWindows
bar = foo
```