### PR TITLE
Add samba_server_max_protocol parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ No specific requirements
 | `samba_passdb_backend`         | `tdbsam`                 | Password database backend.                                            |
 | `samba_realm`                  | -                        | Realm domain name                                                     |
 | `samba_security`               | `user`                   | Samba security setting                                                |
+| `samba_server_min_protocol`    | -                        | Specify a minimum protocol version offered by the server.             |
 | `samba_server_max_protocol`    | -                        | Specify a maximum protocol version offered by the server.             |
 | `samba_server_string`          | `fileserver %m`          | Comment string for the server.                                        |
 | `samba_shares`                 | []                       | List of dicts containing share definitions. See below for details.    |
@@ -220,4 +221,5 @@ Pull requests are also very welcome. The best way to submit a PR is by first cre
 [Paul Montero](https://github.com/lpaulmp),
 [Slavek Jurkowski](https://github.com/slavekjurkowski2),
 [Sven Eeckeman](https://github.com/SvenEeckeman),
-[Tomohiko Ozawa](https://github.com/kota65535).
+[Tomohiko Ozawa](https://github.com/kota65535),
+[Jonathan Underwood](https://github.com/jonathanunderwood).

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ No specific requirements
 | `samba_map_to_guest`           | `bad user`               | Behaviour when unregistered users access the shares.                  |
 | `samba_netbios_name`           | `{{ ansible_hostname }}` | The NetBIOS name of this server.                                      |
 | `samba_passdb_backend`         | `tdbsam`                 | Password database backend.                                            |
-| `samba_realm`                  | -                        | Realm domain name                                                 |
+| `samba_realm`                  | -                        | Realm domain name                                                     |
 | `samba_security`               | `user`                   | Samba security setting                                                |
+| `samba_server_max_protocol`    | -                        | Specify a maximum protocol version offered by the server.             |
 | `samba_server_string`          | `fileserver %m`          | Comment string for the server.                                        |
 | `samba_shares`                 | []                       | List of dicts containing share definitions. See below for details.    |
 | `samba_shares_root`            | `/srv/shares`            | Directories for the shares are created under this directory.          |

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -30,6 +30,11 @@ server string = {{ samba_server_string }}
   guest account = {{ samba_guest_account }}
 {% endif %}
 
+{% if samba_server_min_protocol is defined %}
+  # Minimum protocol version offered by the server
+  server min protocol = {{ samba_server_min_protocol }}
+{% endif %}
+
 {% if samba_server_max_protocol is defined %}
   # Maximum protocol version offered by the server
   server max protocol = {{ samba_server_max_protocol }}

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -30,6 +30,11 @@ server string = {{ samba_server_string }}
   guest account = {{ samba_guest_account }}
 {% endif %}
 
+{% if samba_server_max_protocol is defined %}
+  # Maximum protocol version offered by the server
+  server max protocol = {{ samba_server_max_protocol }}
+{% endif %}
+
 {% if samba_interfaces|length > 0 %}
   interfaces = {{ samba_interfaces }}
 {% endif %}


### PR DESCRIPTION
Sometimes it's necessary to constrain the maximum samba protocol version offered by the server. This new variable allows that.