### PR TITLE
Only create www_documentroot when requested

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,6 +57,7 @@
   file:
     name: "{{ samba_www_documentroot }}"
     state: directory
+  when: samba_create_varwww_symlinks
   tags: samba
 
 - name: Create link to shares in webserver document root


### PR DESCRIPTION
samba_create_varwww_symlinks controls linking to the www docroot but
nothing else requires it to be available.
This commit makes its creation conditional on expected use.

(My server only serves as a backup target - it will never need /var/www!)