### PR TITLE
Support for enabling Apple SMB extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ No specific requirements
 
 | Variable                       | Default                  | Comments                                                                                                            |
 | :---                           | :---                     | :---                                                                                                                |
+| `samba_apple_extensions`       | no                       | When yes, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below)  |
 | `samba_create_varwww_symlinks` | false                    | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform) |
 | `samba_cups_server`            | localhost:631            | Value for the global option `cups server` (only needed when `samba_printer_type` is "cups")                         |
 | `samba_domain_master`          | true                     | When true, smbd enables WAN-wide browse list collation                                                              |
@@ -57,6 +58,7 @@ No specific requirements
 | `samba_shares_root`            | `/srv/shares`            | Directories for the shares are created under this directory.                                                        |
 | `samba_shares`                 | []                       | List of dicts containing share definitions. See below for details.                                                  |
 | `samba_users`                  | []                       | List of dicts defining users that can access shares.                                                                |
+| `samba_vfs_packages`           | Varies by distribution   | List of packages required for Samba VFS support.                                                                    |
 | `samba_wins_support`           | true                     | When true, Samba will act as a WINS server                                                                          |
 | `samba_workgroup`              | `WORKGROUP`              | Name of the server workgroup.                                                                                       |
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,14 @@
   with_items: "{{ samba_packages }}"
   tags: samba
 
+- name: Install Samba VFS extensions packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ samba_vfs_packages }}"
+  when: samba_vfs_packages is defined
+  tags: samba
+
 - name: Install SELinux package
   package:
     name: "{{ item }}"

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -13,6 +13,10 @@
 {% endif %}
   server string = {{ samba_server_string }}
 
+{% if samba_apple_extensions is defined %}
+  fruit:aapl = yes
+{% endif %}
+
   # Logging
 {% if samba_log is defined %}
   log file = {{ samba_log }}

--- a/vars/os_Archlinux.yml
+++ b/vars/os_Archlinux.yml
@@ -5,6 +5,8 @@ samba_packages:
   - samba
   - smbclient
 
+samba_vfs_packages: []
+
 samba_selinux_packages: []
 samba_selinux_booleans: []
 

--- a/vars/os_Debian.yml
+++ b/vars/os_Debian.yml
@@ -6,6 +6,9 @@ samba_packages:
   - samba
   - samba-client
 
+samba_vfs_packages:
+  - samba-vfs-modules
+
 samba_selinux_packages: []
 samba_selinux_booleans: []
 

--- a/vars/os_RedHat.yml
+++ b/vars/os_RedHat.yml
@@ -6,6 +6,8 @@ samba_packages:
   - samba
   - samba-client
 
+samba_vfs_packages: []
+
 samba_selinux_packages:
   - libsemanage-python
 


### PR DESCRIPTION
Adds support for enabling Apples SMB extensions via the VFS fruit module.

This is necessary for Time Machine backups to Samba.

Related to #32