### PR TITLE
Control if shares are browseable or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ A complete overview of share options follows below. Only `name` is required, the
 
 | Option                 | Default                         | Comment                                                                                        |
 | :---                   | :---                            | :---                                                                                           |
+| `browseable`           | -                               | Controls whether this share appears in file browser.                                           |
 | `comment`              | -                               | A comment string for the share                                                                 |
 | `create_mode`          | `0664`                          | See the Samba documentation for details.                                                       |
 | `directory_mode`       | `0775`                          | See the Samba documentation for details.                                                       |

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -114,6 +114,9 @@
 {% if share.guest_ok is defined %}
   guest ok = {{ share.guest_ok }}
 {% endif %}
+{% if share.browseable is defined %}
+  browseable = {{ share.browseable }}
+{% endif %}
 {% if share.writable is defined %}
   writable = {{ share.writable }}
 {% endif %}


### PR DESCRIPTION
Adds the 'browseable' option to shares (as is already available in homes) ;
useful for hiding things like backup targets from casual browsing.