### PR TITLE
Load arbitrary config files in every section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ No specific requirements
 | `samba_create_varwww_symlinks` | false                    | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform) |
 | `samba_cups_server`            | localhost:631            | Value for the global option `cups server` (only needed when `samba_printer_type` is "cups")                         |
 | `samba_domain_master`          | true                     | When true, smbd enables WAN-wide browse list collation                                                              |
+| `samba_global_include`         | -                        | Samba combatible configuration file with options to be loaded to [global] section                                   |
 | `samba_guest_account`          | -                        | Guest account for unknown users                                                                                     |
+| `samba_home_include`           | -                        | Samba combatible configuration file with options to be loaded to [home] section                                     |
 | `samba_interfaces`             | []                       | List of network interfaces used for browsing, name registration, etc.                                               |
 | `samba_load_homes`             | false                    | When true, user home directories are accessible.                                                                    |
 | `samba_load_printers`          | false                    | When true, printers attached to the host are shared                                                                 |
@@ -150,6 +152,7 @@ A complete overview of share options follows below. Only `name` is required, the
 | `comment`              | -                               | A comment string for the share                                                                 |
 | `create_mode`          | `0664`                          | See the Samba documentation for details.                                                       |
 | `directory_mode`       | `0775`                          | See the Samba documentation for details.                                                       |
+| `include_file`         | -                               | Samba combatible configuration file with options to be included for this share.                |
 | `force_create_mode`    | `0664`                          | See the Samba documentation for details.                                                       |
 | `force_directory_mode` | `0775`                          | See the Samba documentation for details.                                                       |
 | `group`                | `users`                         | The user group files in the share will be added to.                                            |

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -73,12 +73,20 @@
   nt pipe support = no
 {% endif %}
 
+{% if samba_global_include is defined %}
+  include = {{ samba_global_include }}
+{% endif %}
+
 {% if samba_load_homes %}
 ## Make home directories accessible
 [homes]
   comment = Home Directories
   browseable = no
   writable = yes
+{% endif %}
+
+{% if samba_home_include is defined %}
+  include = {{ samba_home_include }}
 {% endif %}
 
 {% if samba_shares|length > 0 %}
@@ -121,6 +129,10 @@
   force create mode = {{ share.force_create_mode|default('0664') }}
   directory mode = {{ share.directory_mode|default('0775') }}
   force directory mode = {{ share.force_directory_mode|default('0775') }}
+{% if share.include_file is defined %}
+  include = {{ share.include_file }}
+{% endif %}
 
 {% endfor %}
 {% endif%}
+


### PR DESCRIPTION
This adds loading arbitrary samba config in to the existing sections. In
essence, it allows customising the configuration without making changes to the
role for those who aren't able to readily make the changes they require.

Example usage:

```
    samba_log_level: 1
    samba_global_include: /etc/samba/smb.global-addons.conf
    samba_server_string: Home network backup server
    samba_users:
      - name: timemachine
[ etc ]
  roles:
    - bertvv.samba
  tasks:
  - name: Install custom Samba global setting extras
    template:
      src: templates-shared/samba-global-addons.conf.tmpl
      dest: /etc/samba/smb.global-addons.conf
```

In this instance, the file includes:
```
# {{ ansible_managed }}

# These come from Debians 4.8.4 config file
panic action = /usr/share/samba/panic-action %d
obey pam restrictions = yes
unix password sync = yes
passwd program = /usr/bin/passwd %u
passwd chat = *Enter\snew\s*\spassword:* %n\n *Retype\snew\s*\spassword:* %n\n *password\supdated\ssuccessfully* .
pam password change = yes
```


Closes #32 