### PR TITLE
Control samba log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ No specific requirements
 | `samba_load_homes`             | false                    | When true, user home directories are accessible.                                                                    |
 | `samba_load_printers`          | false                    | When true, printers attached to the host are shared                                                                 |
 | `samba_local_master`           | true                     | When true, nmbd will try & become local master of the subnet                                                        |
-| `samba_log_size`               | 5000                     | Set the maximum size of the log file.                                                                               |
 | `samba_log`                    | -                        | Set the log file. If left undefined, logging is done through syslog.                                                |
+| `samba_log_size`               | 5000                     | Set the maximum size of the log file.                                                                               |
+| `samba_log_level`              | 0                        | Set Samba log level, 0 is least verbose and 10 is a flood of debug output.                                          |
 | `samba_map_to_guest`           | `bad user`               | Behaviour when unregistered users access the shares.                                                                |
 | `samba_mitigate_cve_2017_7494` | true                     | CVE-2017-7494 mitigation breaks some clients, such as macOS High Sierra.                                            |
 | `samba_netbios_name`           | `{{ ansible_hostname }}` | The NetBIOS name of this server.                                                                                    |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 samba_workgroup: 'WORKGROUP'
 samba_server_string: 'Fileserver %m'
 samba_log_size: 5000
+samba_log_level: 0
 samba_interfaces: []
 samba_security: 'user'
 samba_passdb_backend: 'tdbsam'

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -17,6 +17,7 @@
 {% if samba_log is defined %}
   log file = {{ samba_log }}
   max log size = {{ samba_log_size }}
+  log level = {{ samba_log_level }}
 {% else %}
   logging = syslog
 {% endif %}


### PR DESCRIPTION
If logging to a file, allow configuring log levels for debug purposes.