### PR TITLE
include options need absolute paths

### DIFF
--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -91,7 +91,7 @@
 {% endif %}
 
 {% if samba_home_include is defined %}
-  include = {{{ samba_configuration_dir }}/{ samba_home_include }}
+  include = {{ samba_configuration_dir }}/{{ samba_home_include }}
 {% endif %}
 
 {% if samba_shares|length > 0 %}

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -79,7 +79,7 @@
 {% endif %}
 
 {% if samba_global_include is defined %}
-  include = {{ samba_global_include }}
+  include = {{ samba_configuration_dir }}/{{ samba_global_include }}
 {% endif %}
 
 {% if samba_load_homes %}
@@ -91,7 +91,7 @@
 {% endif %}
 
 {% if samba_home_include is defined %}
-  include = {{ samba_home_include }}
+  include = {{{ samba_configuration_dir }}/{ samba_home_include }}
 {% endif %}
 
 {% if samba_shares|length > 0 %}
@@ -138,7 +138,7 @@
   directory mode = {{ share.directory_mode|default('0775') }}
   force directory mode = {{ share.force_directory_mode|default('0775') }}
 {% if share.include_file is defined %}
-  include = {{ share.include_file }}
+  include = {{ samba_configuration_dir }}/{{ share.include_file }}
 {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
I ran into an issue, when the global include directive was ignored. I found that the option in the included file was applied only when using absolute paths. Examples in the samba documentation also use absolute paths. The smb.conf template has been changed to use the {{ samba_configuration_dir }} variable as path prefix.
