### PR TITLE
fix: rename smb and nmb services

### DIFF
--- a/vars/os_Archlinux.yml
+++ b/vars/os_Archlinux.yml
@@ -15,7 +15,7 @@ samba_configuration: "{{ samba_configuration_dir }}/smb.conf"
 samba_username_map_file: "{{ samba_configuration_dir }}/smbusers"
 
 samba_services:
-  - smbd
-  - nmbd
+  - smb
+  - nmb
 
 samba_www_documentroot: /var/www


### PR DESCRIPTION
In samba 4.8.0-1, the units were renamed from smbd.service and nmbd.service to smb.service and nmb.service.

Source: https://wiki.archlinux.org/index.php/Samba#Creating_a_share