### PR TITLE
Update info about mitigating CVE breaking macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ No specific requirements
 | `samba_log_size`               | 5000                     | Set the maximum size of the log file.                                                                                        |
 | `samba_log_level`              | 0                        | Set Samba log level, 0 is least verbose and 10 is a flood of debug output.                                                   |
 | `samba_map_to_guest`           | `bad user`               | Behaviour when unregistered users access the shares.                                                                         |
-| `samba_mitigate_cve_2017_7494` | true                     | CVE-2017-7494 mitigation breaks some clients, such as macOS High Sierra.                                                     |
+| `samba_mitigate_cve_2017_7494` | true                     | CVE-2017-7494 mitigation breaks some clients, such as macOS Catalina, Mojave and High Sierra.                                                     |
 | `samba_netbios_name`           | `{{ ansible_hostname }}` | The NetBIOS name of this server.                                                                                             |
 | `samba_passdb_backend`         | `tdbsam`                 | Password database backend.                                                                                                   |
 | `samba_preferred_master`       | true                     | When true, indicates nmbd is a preferred master browser for workgroup                                                        |


### PR DESCRIPTION
The README says CVE-2017-7494 mitigation breaks some clients, such as macOS High Sierra. I have tested on both Mojave and Catalina and both don't work with the migitation. I changed the information to include those, so people looking to fix a problem on their server can easily find out about this.