### PR TITLE
Add os_Fedora.yml to support Fedora >= 29

### DIFF
--- a/vars/os_Fedora.yml
+++ b/vars/os_Fedora.yml
@@ -1,0 +1,26 @@
+# roles/samba/vars/os_Fedora.yml
+---
+
+samba_packages:
+  - samba-common
+  - samba
+  - samba-client
+
+samba_vfs_packages: []
+
+samba_selinux_packages:
+  - python3-libsemanage
+
+samba_selinux_booleans:
+  - samba_enable_home_dirs
+  - samba_export_all_rw
+
+samba_configuration_dir: /etc/samba
+samba_configuration: "{{ samba_configuration_dir }}/smb.conf"
+samba_username_map_file: "{{ samba_configuration_dir }}/smbusers"
+
+samba_services:
+  - smb
+  - nmb
+
+samba_www_documentroot: /var/www/html


### PR DESCRIPTION
Fedora >= 29 calls the the package to manage SELinux from python python3-libsemanage, which collides with the generic RedHat naming.
Adding a more specific vars file to adapt to that name.