### PR TITLE
Changed selinux_packages for CentOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,4 +250,5 @@ Pull requests are also very welcome. Please create a topic branch for your propo
 [Sven Eeckeman](https://github.com/SvenEeckeman),
 [Tiemo Kieft](https://github.com/blubber),
 [Tobias Wolter](https://github.com/towo),
-[Tomohiko Ozawa](https://github.com/kota65535).
+[Tomohiko Ozawa](https://github.com/kota65535),
+[Lasse Löfquist](https://github.com/tvartom).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: Include OS specific variables
   include_vars: "{{ item }}"
   with_first_found:
+    - "os_{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
     - "os_{{ ansible_distribution }}.yml"
     - "os_{{ ansible_os_family }}.yml"
   tags: samba

--- a/vars/os_CentOS_8.yml
+++ b/vars/os_CentOS_8.yml
@@ -1,0 +1,26 @@
+# roles/samba/vars/os_CentOS_8.yml
+---
+
+samba_packages:
+  - samba-common
+  - samba
+  - samba-client
+
+samba_vfs_packages: []
+
+samba_selinux_packages:
+  - python3-libsemanage
+
+samba_selinux_booleans:
+  - samba_enable_home_dirs
+  - samba_export_all_rw
+
+samba_configuration_dir: /etc/samba
+samba_configuration: "{{ samba_configuration_dir }}/smb.conf"
+samba_username_map_file: "{{ samba_configuration_dir }}/smbusers"
+
+samba_services:
+  - smb
+  - nmb
+
+samba_www_documentroot: /var/www/html


### PR DESCRIPTION
The selinux_package libsemanage-python is replaced by python3-libsemanage in CentOS 8.
I had to tweak the including of OS specific variables to handle different versions. Possibly, it is the same for RHEL 8, but I have no chance to test it, and it is a bit strange to make an include which mixes   ansible_os_family with the version of the distribution.