### PR TITLE
Allow special characters in the password

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -150,7 +150,7 @@
   shell: >
     set -o nounset -o pipefail -o errexit &&
     (pdbedit --user={{ item.name }} 2>&1 > /dev/null) \
-    || (echo {{ item.password }}; echo {{ item.password }}) \
+    || (echo '{{ item.password }}'; echo '{{ item.password }}') \
     | smbpasswd -s -a {{ item.name }}
   args:
     executable: /bin/bash


### PR DESCRIPTION
I propose quoting the password input for `smbpasswd`. This will allow special characters in user's password. Currently, a password like `Test%^$&` will fail silently.