### PR TITLE
Fix AnsibleUndefinedVariable in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     executable: /bin/bash
   register: samba_version
   changed_when: false
+  check_mode: no
   tags: samba
 
 # - name: "Installed Samba version:"


### PR DESCRIPTION
Running "Register Samba version" task also in check mode fixes AnsibleUndefinedVariable error in "Samba configuration" task when using check mode.