### PR TITLE
Make it optional to create share directories

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,4 @@ samba_local_master: 'yes'
 samba_domain_master: 'yes'
 samba_preferred_master: 'yes'
 samba_mitigate_cve_2017_7494: true
+samba_create_directories: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
     owner: root
     group: root
     mode: '0755'
-  when: samba_shares|length > 0
+  when: samba_shares|length > 0 and samba_create_directories|bool
   tags: samba
 
 - name: Create share directories
@@ -71,6 +71,7 @@
     group: "{{ item.group|default('users') }}"
     mode: "{{ item.directory_mode|default('0775') }}"
     setype: "{{ item.setype|default('samba_share_t') }}"
+  when: samba_create_directories|bool
   tags: samba
 
 - name: Ensure webserver document root exists


### PR DESCRIPTION
I manage my share directories and permissions elsewhere and don't want them changed by this role.
I've added an additional option (defaults to true so that existing behaviour is maintained) to allow you to disable creating of directories/setting permissions.

Refs #59

