### PR TITLE
Add `samba_mdns_name` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ No specific requirements
 | `samba_log`                    | -                        | Set the log file. If left undefined, logging is done through syslog.                                                         |
 | `samba_log_size`               | 5000                     | Set the maximum size of the log file.                                                                                        |
 | `samba_log_level`              | 0                        | Set Samba log level, 0 is least verbose and 10 is a flood of debug output.                                                   |
+| `samba_mdns_name`              | `netbios`                | The name advertised via multicast DNS.                                                                                       |
 | `samba_map_to_guest`           | `bad user`               | Behaviour when unregistered users access the shares.                                                                         |
 | `samba_mitigate_cve_2017_7494` | true                     | CVE-2017-7494 mitigation breaks some clients, such as macOS High Sierra.                                                     |
 | `samba_netbios_name`           | `{{ ansible_hostname }}` | The NetBIOS name of this server.                                                                                             |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ samba_interfaces: []
 samba_security: 'user'
 samba_passdb_backend: 'tdbsam'
 samba_map_to_guest: 'never'
+samba_mdns_name: 'netbios'
 samba_load_printers: false
 samba_printer_type: 'cups'
 samba_cups_server: 'localhost:631'

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -7,6 +7,8 @@
   # Server information
   netbios name = {% if samba_netbios_name is defined %}{{ samba_netbios_name }}{% else %}{{ ansible_hostname }}{% endif %}
 
+  mdns name = {% if samba_mdns_name is defined %}{{ samba_mdns_name }}{% else %}netbios{% endif %}
+
   workgroup = {{ samba_workgroup }}
 {% if samba_realm is defined %}
   realm = {{ samba_realm }}


### PR DESCRIPTION
Currently, the NetBIOS name is used both for NetBIOS and mDNS, which conventionally is the hostname in all-uppercase. This option lets users advertise a different name via mDNS.

The `mdns name` configuration option of Samba is [documented here](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#idm6672),