### PR TITLE
Correctly enforce `samba_interfaces` option

### DIFF
--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -48,7 +48,8 @@
 
 {% endif %}
 {% if samba_interfaces|length > 0 %}
-  interfaces = {{ samba_interfaces }}
+  bind interfaces only = yes
+  interfaces = 127.0.0.1 {{ samba_interfaces|join(' ') }}
 
 {% endif %}
   # Name resolution: make sure \\NETBIOS_NAME\ works


### PR DESCRIPTION
Without this change using this option would not generate a valid config file.

Without `bind interfaces only` set to yes the `interfaces` option has no effect. It is now correctly set.
As noted in the official [doc](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#BINDINTERFACESONLY) localhost is also added to not break `smbpasswd`. 