### PR TITLE
Allow passwords with special characters

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -150,7 +150,7 @@
   shell: >
     set -o nounset -o pipefail -o errexit &&
     (pdbedit --user={{ item.name }} 2>&1 > /dev/null) \
-    || (echo {{ item.password }}; echo {{ item.password }}) \
+    || (echo "{{ item.password }}"; echo "{{ item.password }}") \
     | smbpasswd -s -a {{ item.name }}
   args:
     executable: /bin/bash


### PR DESCRIPTION
I noticed that the task to add Samba users with passwords fails if the password contains special characters interpreted by the shell like `!`, `#` etc. because the `echo {{ item.password }}` doesn't encapsulate the password in double quotes. Adding the double quotes to both `echo` usages solves the problem.