### PR TITLE
Add prefix option for vfs_objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,24 @@ samba_shares:
     group: tomcat
 ```
 
+This is an example of configuring the shadow copy vfs object module for sharing a ZFS dataset. This will allow Windows clients to use the `Previous Versions` tab in the share's properties.
+
+```Yaml
+samba_shares:
+  - name: ISO
+    path: /mnt/Tank/ISO
+    vfs_objects:
+      - name: shadow_copy2
+        prefix: shadow
+        options:
+          - name: snapdir
+            value: .zfs/snapshot
+          - name: sort
+            value: desc
+          - name: format
+            value: auto-%Y-%m-%d_%H-%M
+```
+
 A complete overview of share options follows below. Only `name` is required, the rest is optional.
 
 | Option                 | Default                         | Comment                                                                                        |

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -108,7 +108,7 @@
 {% if obj.options is defined %}
 {% if obj.options|length > 0 %}
 {% for opt in obj.options %}
-  {{ obj.name }}:{{ opt.name }} = {{ opt.value }}
+  {{ obj.prefix | default(obj.name) }}:{{ opt.name }} = {{ opt.value }}
 {% endfor %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Currently the `name` attribute is used as the prefix for each VFS option. This patch would add an optional `prefix` attribute to `vfs_objects`. This would allow use of the [`shadow_copy2`](https://www.samba.org/samba/samba/docs/man/manpages/vfs_shadow_copy2.8.html) Samba VFS module which requires the `prefix` to be `shadow`.